### PR TITLE
fix(Makefile): remove deprecated glide flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ NV := $(shell glide nv)
 
 # Set up the development environment
 setup:
-	glide up --import --delete-flatten
+	glide up
 
 build:
 	go build -o ${BINDIR}/boot -a -installsuffix cgo -ldflags ${LDFLAGS}  boot.go


### PR DESCRIPTION
These flags have since been removed and are no longer available in glide 0.7.
