### PR TITLE
Update etcd and more

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
-rootfs/bin/boot
-rootfs/bin/discovery
+rootfs/usr/local/bin/*
 vendor/

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ export GO15VENDOREXPERIMENT=1
 export CGO_ENABLED=0
 
 # Environmental details
-BINDIR := rootfs/bin
+BINDIR := rootfs/usr/local/bin
 VERSION := 0.0.1-$(shell date "+%Y%m%d%H%M%S")
 LDFLAGS := "-s -X main.version=${VERSION}"
 IMAGE := ${DEIS_REGISTRY}/deis/${SHORT_NAME}:${VERSION}

--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@ Kubernetes' Docker instances to allow the `--insecure-registry`.
    heartbeats layer, so it must stay running in order to help a failed
    cluster rebuild.
 5. This project builds one Docker image that has two executable paths.
-   If it is started with the `/bin/boot`, it will be an etcd cluster
-   member. If it is started with `/bin/discovery` it will come up as a
+   If it is started with the `/usr/local/bin/boot`, it will be an etcd cluster
+   member. If it is started with `/usr/local/bin/discovery` it will come up as a
    discovery service.
 
 Finally, this distribution will _not_ work outside of Kubernetes unless

--- a/manifests/deis-etcd-discovery-rc.json
+++ b/manifests/deis-etcd-discovery-rc.json
@@ -31,7 +31,7 @@
                {
                   "name":"deis-etcd-discovery",
                   "image":"192.168.99.100:5000/deis/etcd:0.0.1-2-g0d0e135",
-                  "command": ["/bin/discovery"],
+                  "command": ["/usr/local/bin/discovery"],
                   "ports": [
                     {
                       "containerPort":2381

--- a/rootfs/.dockerignore
+++ b/rootfs/.dockerignore
@@ -1,0 +1,3 @@
+.dockerignore
+Dockerfile
+README.md

--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -1,15 +1,14 @@
 FROM alpine:3.2
 
-COPY . /
-
-# Install Etcd and EtcdCtl
+# Install etcd and etcdctl
 RUN apk add --update-cache curl tar \
     && curl -sSL https://github.com/coreos/etcd/releases/download/v2.2.1/etcd-v2.2.1-linux-amd64.tar.gz \
     | tar -vxz -C /usr/local/bin --strip=1 etcd-v2.2.1-linux-amd64/etcd etcd-v2.2.1-linux-amd64/etcdctl \
+    && chown root:root /usr/local/bin/etcd /usr/local/bin/etcdctl \
     && apk del --purge curl tar \
     && rm -rf /var/cache/apk/*
 
-RUN chmod +x /bin/boot /bin/discovery
+COPY . /
 
 EXPOSE 2380 4100 2381
-CMD ["/bin/boot"]
+CMD ["/usr/local/bin/boot"]

--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -1,18 +1,13 @@
-FROM alpine:3.1
-
-RUN apk add --update-cache curl \
-    && rm -rf /var/cache/apk/*
+FROM alpine:3.2
 
 COPY . /
-WORKDIR /opt
 
 # Install Etcd and EtcdCtl
-RUN curl -sSL https://github.com/coreos/etcd/releases/download/v2.2.0-rc.0/etcd-v2.2.0-rc.0-linux-amd64.tar.gz -o /opt/etcd.tgz \
-    && tar -zxf /opt/etcd.tgz \
-    && mv /opt/etcd-v2.2.0-rc.0-linux-amd64/etcd /usr/local/bin/etcd \
-    && mv /opt/etcd-v2.2.0-rc.0-linux-amd64/etcdctl /usr/local/bin/etcdctl \
-    && chmod +x /usr/local/bin/etcd \
-    && rm -rf /opt/etcd-v2.2.0-rc.0-linux-amd64 /opt/etcd.tgz
+RUN apk add --update-cache curl tar \
+    && curl -sSL https://github.com/coreos/etcd/releases/download/v2.2.1/etcd-v2.2.1-linux-amd64.tar.gz \
+    | tar -vxz -C /usr/local/bin --strip=1 etcd-v2.2.1-linux-amd64/etcd etcd-v2.2.1-linux-amd64/etcdctl \
+    && apk del --purge curl tar \
+    && rm -rf /var/cache/apk/*
 
 RUN chmod +x /bin/boot /bin/discovery
 

--- a/rootfs/README.md
+++ b/rootfs/README.md
@@ -18,9 +18,9 @@ interested in deploying the smallest possible images.
 Example:
 
 ```Dockerfile
-FROM alpine:3.1
+FROM alpine:3.2
 
 COPY . /
 
-ENTRYPOINT ["/bin/boot"]
+ENTRYPOINT ["/usr/local/bin/boot"]
 ```


### PR DESCRIPTION
Updates to `alpine:3.2`, updates `etcd` to 2.2.1, moves all our binaries to /usr/local/bin for consistency, makes the resulting Docker image about 30MB smaller.
