### PR TITLE
feat(makefile): use build tag in place of seconds for image version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,8 @@
 # 	all be in $DEIS/vendor
 SHORT_NAME ?= etcd
 
+BUILD_TAG ?= git-$(shell git rev-parse --short HEAD)
+
 # Set these if they are not present in the environment.
 export GOARCH ?= amd64
 export GOOS ?= linux
@@ -15,10 +17,9 @@ export CGO_ENABLED=0
 
 # Environmental details
 BINDIR := rootfs/usr/local/bin
-VERSION ?= 0.0.1-$(shell date "+%Y%m%d%H%M%S")
-LDFLAGS := "-s -X main.version=${VERSION}"
+LDFLAGS := "-s -X main.version=${BUILD_TAG}"
 IMAGE_PREFIX ?= deisci
-IMAGE := ${DEIS_REGISTRY}${IMAGE_PREFIX}/${SHORT_NAME}:${VERSION}
+IMAGE := ${DEIS_REGISTRY}${IMAGE_PREFIX}/${SHORT_NAME}:${BUILD_TAG}
 RC := ${MANIFESTS}/deis-${SHORT_NAME}-rc.yaml
 DISCOVERY_RC := ${MANIFESTS}/deis-${SHORT_NAME}-discovery-rc.yaml
 
@@ -34,7 +35,7 @@ build:
 	go build -o ${BINDIR}/discovery -a -installsuffix cgo -ldflags ${LDFLAGS} discovery.go
 
 info:
-	@echo "Version:    ${VERSION}"
+	@echo "Build tag:  ${BUILD_TAG}"
 	@echo "Registry:   ${DEIS_REGISTRY}"
 	@echo "Go flags:   GOOS=${GOOS} GOARCH=${GOARCH} CGO_ENABLED=${CGO_ENABLED}"
 	@echo "Image:      ${IMAGE}"


### PR DESCRIPTION
This changes the image version to be based on the git short tag instead of the current seconds. Currently, the `make (build|push|kube-rc|kube-update)` commands can not be used individually, as time will have moved on and the image name will constantly change.

Im not sure what the motivation was for using seconds was initially, so maybe this change isnt necessary - but this change made troubleshooting my own etcd issues a little easier.
