### PR TITLE
fix(makefile): silence error message when registry isn't named deis

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ SHORT_NAME ?= etcd
 export GOARCH ?= amd64
 export GOOS ?= linux
 export MANIFESTS ?= ./manifests
-export DEV_REGISTRY ?= "$(shell docker-machine ip deis):5000"
+export DEV_REGISTRY ?= "$(shell docker-machine ip deis 2>&1):5000"
 export DEIS_REGISTRY ?= ${DEV_REGISTRY}/
 
 # Non-optional environment variables


### PR DESCRIPTION
I named mine differently and I also set `DEIS_REGISTRY` so I was seeing an error message fly by that doesn't need to be seen
