### PR TITLE
fix(Makefile): remove call to docker-machine

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,6 @@ SHORT_NAME ?= etcd
 export GOARCH ?= amd64
 export GOOS ?= linux
 export MANIFESTS ?= ./manifests
-export DEV_REGISTRY ?= "$(shell docker-machine ip deis 2>&1):5000"
 export DEIS_REGISTRY ?= ${DEV_REGISTRY}/
 
 # Non-optional environment variables


### PR DESCRIPTION
In other projects, we do not dictate how DEIS_REGISTRY or DEV_REGISTRY
is set, other than DEIS_REGISTRY is the successor to DEV_REGISTRY. This is handled by the developer. This fixes Travis and should allow deis/etcd to push images to quay once again.

fixes #14
