### PR TITLE
fix(travis): skip cleanup step during deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ install:
 script:
   - make test
 deploy:
+  skip_cleanup: true
   provider: script
   script: _scripts/deploy.sh
   on:


### PR DESCRIPTION
fixes up the issues with the deploy step on Travis CI. An example build with this change can be seen here: https://travis-ci.org/bacongobbler/etcd/builds/95666758
