### PR TITLE
fix(manifest): remove namespace from disco svc manifest

### DIFF
--- a/manifests/deis-etcd-discovery-service.yaml
+++ b/manifests/deis-etcd-discovery-service.yaml
@@ -2,7 +2,6 @@ kind: Service
 apiVersion: v1
 metadata:
   name: deis-etcd-discovery
-  namespace: deis
   labels:
     name: deis-etcd-discovery
     app: deis


### PR DESCRIPTION
This seemingly errant namespace breaks my ability to stand up the cluster via the Makefile - the result is a consistent CrashLoopBackOff.

If this is not accidental, adding some words about how to avoid this failure would be useful.
