### PR TITLE
fix(makefile): fixes #24

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ rootfs/usr/local/bin/*
 vendor/
 boot
 discovery
+manifests/*.tmp.yaml

--- a/manifests/deis-etcd-discovery-service.yaml
+++ b/manifests/deis-etcd-discovery-service.yaml
@@ -2,7 +2,6 @@ kind: Service
 apiVersion: v1
 metadata:
   name: deis-etcd-discovery
-  namespace: deis
   labels:
     name: deis-etcd-discovery
     app: deis


### PR DESCRIPTION
This pr does a few things:
#1: it adds a new task kube-create which starts the etcd cluster in the proper order.
#2: it removes the perl replacement for sed like the other makefiles
#3: it uses tmp files for starting the etcd cluster instead of the main yaml files.
