### PR TITLE
fix(deploy.sh): use BUILD_TAG instead of VERSION

### DIFF
--- a/_scripts/deploy.sh
+++ b/_scripts/deploy.sh
@@ -5,7 +5,7 @@
 
 cd "$(dirname "$0")" || exit 1
 
-export IMAGE_PREFIX=deisci VERSION=v2-alpha
+export IMAGE_PREFIX=deisci BUILD_TAG=v2-alpha
 docker login -e="$DOCKER_EMAIL" -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
 DEIS_REGISTRY='' make -C .. docker-build docker-push
 docker login -e="$QUAY_EMAIL" -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" quay.io


### PR DESCRIPTION
this is what's preventing CI from updating `v2-alpha` on new pushes. Discovered by @jchauncey 
