### PR TITLE
fix(boot): handle missing pod IP, name, namespace

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,8 @@ services:
   - docker
 sudo: required
 before_install:
-  - wget "https://github.com/Masterminds/glide/releases/download/0.7.2/glide-0.7.2-linux-amd64.tar.gz"
-  - sudo tar -vxz -C /usr/local/bin --strip=1 -f glide-0.7.2-linux-amd64.tar.gz
+  - wget "https://github.com/Masterminds/glide/releases/download/0.8.1/glide-0.8.1-linux-amd64.tar.gz"
+  - sudo tar -vxz -C /usr/local/bin --strip=1 -f glide-0.8.1-linux-amd64.tar.gz
 install:
   - GLIDE_HOME=/home/travis/.glide make bootstrap
 script:

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ NV := $(shell glide nv)
 
 # Set up the development environment
 bootstrap:
-	glide up
+	glide install
 
 build:
 	go build -o ${BINDIR}/boot -a -installsuffix cgo -ldflags ${LDFLAGS} boot.go

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-updated: 2015-12-08T13:50:03.054926071-07:00
+updated: 2015-12-17T16:03:21.283876671-07:00
 imports:
 - name: bitbucket.org/bertimus9/systemstat
   version: 1468fd0db20598383c9393cccaa547de6ad99e5e
@@ -180,7 +180,7 @@ imports:
 - name: github.com/deckarep/golang-set
   version: ef32fa3046d9f249d399f98ebaf9be944430fd1d
 - name: github.com/deis/pkg
-  version: 6378ff976348b8fcc69a24ee9528e74bcda2ddc6
+  version: ee60d947fecd410bd9ea30ffb53f9ea3e6dc038e
 - name: github.com/denverdino/aliyungo
   version: 0e0f322d0a54b994dea9d32541050d177edf6aa3
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -8,7 +8,7 @@ import:
   - package: github.com/coreos/etcd
     version: ~2.2
   - package: github.com/deis/pkg
-    version: ">=0.2.0"
+    version: ">=0.2.1"
   - package: github.com/steveeJ/gexpect
     repo: https://github.com/coreos/gexpect
   - package: code.google.com/p/goprotobuf


### PR DESCRIPTION
This adds some recovery for the case where we cannot contact the
k8s api server. Downward API actually gives us most of what we
need, though the IP scanning is less reliable.
